### PR TITLE
use correct rpc port

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -552,6 +552,20 @@
         "once": "^1.4.0"
       }
     },
+    "execa": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+      "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+      "requires": {
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^4.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
+      }
+    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -675,6 +689,14 @@
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
       "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g=="
     },
+    "get-stream": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+      "requires": {
+        "pump": "^3.0.0"
+      }
+    },
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
@@ -772,6 +794,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-file/-/is-file-1.0.0.tgz",
       "integrity": "sha1-KKRM+9nT2xkwRfIrZfzo7fliBZY="
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -1135,6 +1162,14 @@
       "integrity": "sha512-L/Eg02Epx6Si2NXmedx+Okg+4UHqmaf3TNcxd50SF9NQGcJaON3AtU++kax69XV7YWz4tUspqZSAsVofhFKG2w==",
       "optional": true
     },
+    "npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "requires": {
+        "path-key": "^2.0.0"
+      }
+    },
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
@@ -1147,6 +1182,11 @@
       "requires": {
         "wrappy": "1"
       }
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
     "package-json-versionify": {
       "version": "1.0.4",
@@ -1406,6 +1446,11 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
     },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+    },
     "simple-concat": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
@@ -1572,6 +1617,11 @@
       "requires": {
         "safe-buffer": "~5.1.0"
       }
+    },
+    "strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "tar": {
       "version": "4.4.8",

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   "license": "MIT",
   "dependencies": {
     "bitcoin-core": "^2.0.0",
-    "cross-spawn": "^6.0.5",
     "debug": "^4.1.1",
+    "execa": "1.0.0",
     "mkdirp": "^0.5.1",
     "progress": "^2.0.3",
     "rimraf": "^2.6.3",

--- a/src/index.js
+++ b/src/index.js
@@ -83,6 +83,7 @@ function node (opts = {}) {
   let rpc = new RpcClient({
     username: opts.rpcuser,
     password: opts.rpcpassword,
+    port: opts.rpcport,
     network,
     logger: { debug }
   })

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@
 
 let { randomBytes } = require('crypto')
 let debug = require('debug')('bitcoind')
-let _spawn = require('cross-spawn')
+let _spawn = require('execa')
 let RpcClient = require('bitcoin-core')
 let flags = require('./flags.js')
 
@@ -33,7 +33,7 @@ function spawn (opts) {
   }
 
   let promise = new Promise((resolve, reject) => {
-    child.once('exit', (code) => {
+    child.once('exit', code => {
       if (code !== 0) {
         let err
         if (Date.now() - start < 1000) {
@@ -53,7 +53,7 @@ function spawn (opts) {
   return child
 }
 
-function maybeError (res) {
+function maybeError(res) {
   if (res.killed) return
   if (res.then != null) {
     return res.then(maybeError)
@@ -63,12 +63,15 @@ function maybeError (res) {
   }
 }
 
-function node (opts = {}) {
-  opts = Object.assign({
-    server: true,
-    rpcuser: randomString(),
-    rpcpassword: randomString()
-  }, opts)
+function node(opts = {}) {
+  opts = Object.assign(
+    {
+      server: true,
+      rpcuser: randomString(),
+      rpcpassword: randomString()
+    },
+    opts
+  )
 
   if (opts.rpcport == null && opts.regtest) {
     opts.rpcport = 18332
@@ -91,7 +94,7 @@ function node (opts = {}) {
   let started
   return Object.assign(child, {
     rpc,
-    started (timeout) {
+    started(timeout) {
       if (started) return started
       started = waitForRpc(rpc, child, timeout)
       return started
@@ -99,13 +102,13 @@ function node (opts = {}) {
   })
 }
 
-let waitForRpc = wait(async (client) => {
+let waitForRpc = wait(async client => {
   await client.getNetworkInfo()
   return true
 })
 
-function wait (condition) {
-  return async function (client, child, timeout = 30 * 1000) {
+function wait(condition) {
+  return async function(client, child, timeout = 30 * 1000) {
     let start = Date.now()
     while (true) {
       let elapsed = Date.now() - start
@@ -122,11 +125,11 @@ function wait (condition) {
   }
 }
 
-function sleep (ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms))
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms))
 }
 
-function randomString () {
+function randomString() {
   return randomBytes(10).toString('base64')
 }
 


### PR DESCRIPTION
fixes an issue where you'd get a "timed out while waiting error" on `await bitcoind.started()` if you used a non-default rpc port. now the `bitcoin-core` rpc client will respect the given `opts.rpcport` too.